### PR TITLE
make code blocks readable when js is disabled

### DIFF
--- a/components/codeSnippet.tsx
+++ b/components/codeSnippet.tsx
@@ -28,7 +28,7 @@ const CodeSnippet: FC<Props> = ({ slice }) => {
             </CopyToClipboard>
           </div>
         </div>
-        <pre className="text-xs overflow-x-scroll pl-2 py-1">
+        <pre className="text-xs overflow-x-scroll pl-2 py-1 text-white">
           <code className={language}>{code}</code>
         </pre>
       </div>


### PR DESCRIPTION
When a reader views the site with javascript disabled, highlight.js can't style code blocks. The blocks therefore inherit the default text colour (`black`) on the dark `code-background` colour, making them completely unreadable. 

This quick fix sets the default colour for code to `white` instead of `black`. 

Longer-term, it would be great to make highlight.js run during the build, rather than styling the code when it's viewed. That way, people viewing the site with js disabled will still get the benefit of reading syntax-highlighted code.